### PR TITLE
obfuscate_project tool compatibility update for Xcode >= 5

### DIFF
--- a/contrib/obfuscate_project
+++ b/contrib/obfuscate_project
@@ -10,7 +10,7 @@ CONFIGURATION=Release
 SDK=7.1
 
 # Additional build options
-XCTOOL_OPTS=""
+XCODEBUILD_OPTS=""
 CLASS_GUARD_OPTS="-i IgnoredSymbol -F !ExcludedClass"
 
 ####################################################
@@ -45,14 +45,15 @@ rm -rf build/
 [[ -f Pods/Pods.xcodeproj/project.pbxproj ]] && CLASS_GUARD_OPTS="$CLASS_GUARD_OPTS -P Pods/Pods.xcodeproj/project.pbxproj"
 
 # Build project to fetch symbols
-[[ -n "$WORKSPACE" ]] && XCTOOL_OPTS="$XCTOOL_OPTS -workspace $WORKSPACE"
-[[ -n "$PROJECT" ]] && XCTOOL_OPTS="$XCTOOL_OPTS -project $PROJECT"
-[[ -n "$SCHEME" ]] && XCTOOL_OPTS="$XCTOOL_OPTS -scheme $SCHEME"
-[[ -n "$CONFIGURATION" ]] && XCTOOL_OPTS="$XCTOOL_OPTS -configuration $CONFIGURATION"
-[[ -n "$SDK" ]] && XCTOOL_OPTS="$XCTOOL_OPTS -sdk iphoneos$SDK"
+[[ -n "$WORKSPACE" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -workspace $WORKSPACE"
+[[ -n "$PROJECT" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -project $PROJECT"
+[[ -n "$SCHEME" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -scheme $SCHEME"
+[[ -n "$CONFIGURATION" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -configuration $CONFIGURATION"
+[[ -n "$SDK" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -sdk iphoneos$SDK"
 
-echo_and_run xctool $XCTOOL_OPTS \
+echo_and_run xcodebuild $XCODEBUILD_OPTS \
     clean build \
+    -derivedDataPath build
     OBJROOT=build/ \
     SYMROOT=build/
 
@@ -62,8 +63,20 @@ echo_and_run find . -name '*-Prefix.pch' -exec sed -i .bak '1i\
 " "{}" \;
 
 # Obfuscate project
-for app in build/*/*.app
+appsNumber=0;
+while read app
 do
+    if ((appsNumber > 0))
+    then
+        echo ""
+        echo ""
+        echo "You cannot use this tool when there is more than one .app file in products. Otherwise, only the first one will be used for obfuscation."
+        echo ""
+        echo ""
+        exit
+    fi
+    ((appsNumber+=1))
+
     TARGET=$(basename "$app" .app)
     echo "Obfuscating $TARGET in $app..."
     echo_and_run ios-class-guard \
@@ -71,8 +84,7 @@ do
         $CLASS_GUARD_OPTS \
         -O "$SYMBOLS_FILE" \
         "$app/$TARGET"
-    break
-done
+done < <(find build/ -name '*.app')
 
 echo ""
 echo ""

--- a/contrib/obfuscate_project
+++ b/contrib/obfuscate_project
@@ -13,6 +13,9 @@ SDK=7.1
 XCODEBUILD_OPTS=""
 CLASS_GUARD_OPTS="-i IgnoredSymbol -F !ExcludedClass"
 
+# In case of using Xcode >= 6 and SDK >= 8
+CLASS_GUARD_OPTS_SDK="--sdk-root /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$SDK.sdk"
+
 ####################################################
 # BUILD SCRIPT STARTS HERE
 ####################################################
@@ -49,7 +52,15 @@ rm -rf build/
 [[ -n "$PROJECT" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -project $PROJECT"
 [[ -n "$SCHEME" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -scheme $SCHEME"
 [[ -n "$CONFIGURATION" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -configuration $CONFIGURATION"
-[[ -n "$SDK" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -sdk iphoneos$SDK"
+
+xcodeversion=`xcodebuild -version | grep -oE '^Xcode\s+\d+' | grep -oE '\d+'`
+if ((xcodeversion > 5)) || ((SDK >= 8.0))
+then
+    [[ -n "$SDK" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -sdk iphonesimulator$SDK"
+else
+    [[ -n "$SDK" ]] && XCODEBUILD_OPTS="$XCODEBUILD_OPTS -sdk iphoneos$SDK"
+    [[ -n "$SDK" ]] && CLASS_GUARD_OPTS_SDK="--sdk-ios $SDK"
+fi
 
 echo_and_run xcodebuild $XCODEBUILD_OPTS \
     clean build \
@@ -73,14 +84,14 @@ do
         echo "You cannot use this tool when there is more than one .app file in products. Otherwise, only the first one will be used for obfuscation."
         echo ""
         echo ""
-        exit
+        exit 1
     fi
     ((appsNumber+=1))
 
     TARGET=$(basename "$app" .app)
     echo "Obfuscating $TARGET in $app..."
     echo_and_run ios-class-guard \
-        --sdk-ios "$SDK" \
+        $CLASS_GUARD_OPTS_SDK \
         $CLASS_GUARD_OPTS \
         -O "$SYMBOLS_FILE" \
         "$app/$TARGET"


### PR DESCRIPTION
fix for possible failures while obfuscating projects with Cocoapods using Xcode 6;
added information in case of more than one .app file in build products;
using Simulator SDK in case of Xcode>=6 or SDK>=8;