### PR TITLE
Import patch to correspond to swift's object from original class-dump.

### DIFF
--- a/Source/CDOCClass.h
+++ b/Source/CDOCClass.h
@@ -15,5 +15,6 @@
 @property (copy, readonly) NSString *superClassName;
 @property (strong) NSArray *instanceVariables;
 @property (assign) BOOL isExported;
+@property (assign) BOOL isSwiftClass;
 
 @end

--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -218,7 +218,11 @@
     objc2Class.superclass = [cursor readPtr];
     objc2Class.cache      = [cursor readPtr];
     objc2Class.vtable     = [cursor readPtr];
-    objc2Class.data       = [cursor readPtr];
+
+    uint64_t value        = [cursor readPtr];
+    class.isSwiftClass    = (value & 0x1) != 0;
+    objc2Class.data       = value & ~7;
+
     objc2Class.reserved1  = [cursor readPtr];
     objc2Class.reserved2  = [cursor readPtr];
     objc2Class.reserved3  = [cursor readPtr];


### PR DESCRIPTION
If an application to be obfuscated contains an object of Swift, it will result in a "can not find offset for address in string" error, so we will import the patch for the swift object from the original class-dump.

I think You should be able to get the same effect by just merging upstream changes.